### PR TITLE
GHRCCLOUD-7769: Updating to latest cumulus-api-python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 
-cumulus-api @ https://github.com/ghrcdaac/cumulus-api/archive/refs/tags/v3.0.6.zip
+cumulus-api @ https://github.com/nasa/Cumulus-API-Python/archive/refs/tags/v3.1.0.zip
 tabulate==0.9.0
 types-tabulate==0.9.0.20241207


### PR DESCRIPTION
- Updating dependency to point to new open source location (NASA repo)
- Updating dependency version to include latest Cumulus changes

Dependency updates PR: https://github.com/nasa/Cumulus-API-Python/pull/1