### PR TITLE
Hotfix: Update repo url references and version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,6 @@
  name: Build & Test
  on:
    pull_request:
-   push:
 
  jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@
     name: Build & Test
     strategy:
       matrix:
-        python-version: ['3.10' ]
+        python-version: ['3.12' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Python 3.12+
 
 ## Installation
 ```jsunicoderegexp
-pip install https://github.com/nasa/GHRC-PyLOT/archive/refs/tags/v3.0.3.zip
+pip install https://github.com/nasa/GHRC-PyLOT/archive/refs/tags/v3.1.0.zip
 ```
 ## Set up
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/ghrcdaac/cloud-operations-tool-py/badge.svg)](https://coveralls.io/github/ghrcdaac/cloud-operations-tool-py)
-![Build Status](https://github.com/ghrcdaac/cloud-operations-tool-py/actions/workflows/build-and-test.yml/badge.svg?branch=main)
+[![Build & Test](https://github.com/nasa/GHRC-PyLOT/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/nasa/GHRC-PyLOT/actions/workflows/build-and-test.yml)
 <p align="center">
 <img src="img/pylot.svg"
      alt="pylot" width=50%/>
@@ -32,19 +31,19 @@ This tool will prevent reinventing the wheel, since a solution for a common prob
 ```
 
 ## Prerequisites
-Python 3.8+
+Python 3.12+
 
 ## Installation
 ```jsunicoderegexp
-pip install https://github.com/ghrcdaac/cloud-operations-tool-py/archive/refs/tags/v1.0.0.zip
+pip install https://github.com/nasa/GHRC-PyLOT/archive/refs/tags/v3.0.3.zip
 ```
 ## Set up
 ```bash
 Copy file
-https://github.com/ghrcdaac/cloud-operations-tool-py/blob/main/env.sh.example
+https://github.com/nasa/GHRC-PyLOT/blob/main/env.sh.example
 Define environment variable and source the file
 ```
 
 ## 📖 Documentation
-- ❓[HowTo](https://ghrcdaac.github.io/cloud-operations-tool-py/howto)
-- 🚀 Release note [v1.0.0](https://github.com/ghrcdaac/cloud-operations-tool-py/releases/tag/v1.0.0).
+- ❓[HowTo](https://nasa.github.io/GHRC-PyLOT/howto)
+- 🚀 Release note [v3.1.0](https://github.com/nasa/GHRC-PyLOT/releases/tag/v3.1.0).

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 here = path.abspath(path.dirname(__file__))
 
-__version__ = "1.0.5"
+__version__ = "3.1.0"
 
 description = """
 Python cLoud Operations Tool (PyLOT) is a python command line tool designed to
@@ -22,9 +22,10 @@ install_requires = [x.strip() for x in all_reqs]
 setup(
     name='cloud_operations_tool',
     version=__version__,
-    author='Abdelhak Marouane (am0089@uah.edu), Michael Hall (mlh0079@uah.edu)',
+    author='Abdelhak Marouane, Michael Hall',
+    maintainer='GHRC DAAC Development Team'
     description=description,
-    url='https://github.com/ghrcdaac/cloud-operations-tool-py',
+    url='https://github.com/nasa/GHRC-PyLOT',
     license='Apache 2.0',
     classifiers=[
         'Framework :: Pytest',
@@ -32,7 +33,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: Freeware',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.12',
     ],
     entry_points={
         'console_scripts': ['pylot=pylot.pylot_cli:main']

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name='cloud_operations_tool',
     version=__version__,
     author='Abdelhak Marouane, Michael Hall',
-    maintainer='GHRC DAAC Development Team'
+    maintainer='GHRC DAAC Development Team',
     description=description,
     url='https://github.com/nasa/GHRC-PyLOT',
     license='Apache 2.0',


### PR DESCRIPTION
- Update URLs to point to NASA repo instead of archived `ghrcdaac` repo.
- Update version references to latest _to be published_ version